### PR TITLE
Modify header container to prevent logo and nav from reaching edges at smaller resolutions

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -13,8 +13,9 @@ const EmptyTag = Fragment;
 
 // @todo cleanup later as a part of Wrap
 const wrapStyle = {
-  maxWidth: '62.5em',
+  maxWidth: '65.1rem',
   margin: '0 auto',
+  padding: '0 1.33333rem',
   position: 'relative',
 };
 

--- a/src/scss/modules/header.module.scss
+++ b/src/scss/modules/header.module.scss
@@ -8,10 +8,6 @@
   @include size-tablet-down {
     top: 16px;
   }
-
-  @include size-medium-down {
-    left: 24px;
-  }
 }
 
 .link {

--- a/src/scss/modules/sitenav.module.scss
+++ b/src/scss/modules/sitenav.module.scss
@@ -23,7 +23,7 @@
 }
 
 .nav {
-  padding: 48px 24px 48px 0;
+  padding: 48px 72px 48px 0;
   position: absolute;
   width: 100%;
   z-index: 1000;


### PR DESCRIPTION
This modifies the top header so the logo and nav are never flush with the document edges, here are screenshots at larger, mid, and lower res:

<img width="1392" alt="screen shot 2018-10-30 at 1 04 27 am" src="https://user-images.githubusercontent.com/272624/47704145-e4f12900-dbdf-11e8-91ee-6df247bdac13.png">
<img width="1162" alt="screen shot 2018-10-30 at 1 06 12 am" src="https://user-images.githubusercontent.com/272624/47704200-0c47f600-dbe0-11e8-9648-a12c3297bad2.png">
<img width="1105" alt="screen shot 2018-10-30 at 1 04 31 am" src="https://user-images.githubusercontent.com/272624/47704146-e6225600-dbdf-11e8-833c-a46442dcf8c6.png">

